### PR TITLE
Update entrypoint and action configuration for force-push

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,19 +19,19 @@ inputs:
     description: Email for the git commit
     required: true
   github-server:
-    description: 'Github server'
-    default: 'github.com'
+    description: "Github server"
+    default: "github.com"
     required: false
   user-name:
     description: >-
       [Optional] Name for the git commit. Defaults to the destination
       username/organization name
     required: false
-    default: ''
+    default: ""
   destination-repository-username:
-    description: '[Optional] Username/organization for the destination repository'
+    description: "[Optional] Username/organization for the destination repository"
     required: false
-    default: ''
+    default: ""
   target-branch:
     description: >-
       [Optional] set target branch name for the destination repository. Defaults
@@ -45,8 +45,8 @@ inputs:
     default: Update from ORIGIN_COMMIT
     required: false
   target-directory:
-    description: '[Optional] The directory to wipe and replace in the target repository'
-    default: ''
+    description: "[Optional] The directory to wipe and replace in the target repository"
+    default: ""
     required: false
   create-target-branch-if-needed:
     type: boolean
@@ -59,18 +59,19 @@ runs:
   using: docker
   image: Dockerfile
   args:
-    - '${{ inputs.source-before-directory }}'
-    - '${{ inputs.source-directory }}'
-    - '${{ inputs.destination-github-username }}'
-    - '${{ inputs.destination-repository-name }}'
-    - '${{ inputs.github-server }}'
-    - '${{ inputs.user-email }}'
-    - '${{ inputs.user-name }}'
-    - '${{ inputs.destination-repository-username }}'
-    - '${{ inputs.target-branch }}'
-    - '${{ inputs.commit-message }}'
-    - '${{ inputs.target-directory }}'
-    - '${{ inputs.create-target-branch-if-needed }}'
+    - "${{ inputs.source-before-directory }}"
+    - "${{ inputs.source-directory }}"
+    - "${{ inputs.destination-github-username }}"
+    - "${{ inputs.destination-repository-name }}"
+    - "${{ inputs.github-server }}"
+    - "${{ inputs.user-email }}"
+    - "${{ inputs.user-name }}"
+    - "${{ inputs.destination-repository-username }}"
+    - "${{ inputs.target-branch }}"
+    - "${{ inputs.commit-message }}"
+    - "${{ inputs.target-directory }}"
+    - "${{ inputs.create-target-branch-if-needed }}"
+    - "${{ inputs.force-push }}"
 branding:
   icon: git-commit
   color: green

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,12 @@ inputs:
       [Optional] create target branch if not exist. Defaults to `false`
     default: false
     required: false
+  force-push: 
+    type: boolean
+    description: >-
+      [Optional] force push. Defaults to `false`
+    default: false
+    required: false
 
 runs:
   using: docker

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,7 @@ TARGET_BRANCH="${9}"
 COMMIT_MESSAGE="${10}"
 TARGET_DIRECTORY="${11}"
 CREATE_TARGET_BRANCH_IF_NEEDED="${12}"
+FORCE_PUSH="${13}"
 
 if [ -z "$DESTINATION_REPOSITORY_USERNAME" ]
 then
@@ -172,4 +173,9 @@ git diff-index --quiet HEAD || git commit --message "$COMMIT_MESSAGE"
 
 echo "[+] Pushing git commit"
 # --set-upstream: sets de branch when pushing to a branch that does not exist
-git push "$GIT_CMD_REPOSITORY" --set-upstream "$TARGET_BRANCH" --force
+if [ "$FORCE_PUSH" = "true" ]
+then
+	git push "$GIT_CMD_REPOSITORY" --set-upstream "$TARGET_BRANCH" --force
+else
+	git push "$GIT_CMD_REPOSITORY" --set-upstream "$TARGET_BRANCH"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -172,4 +172,4 @@ git diff-index --quiet HEAD || git commit --message "$COMMIT_MESSAGE"
 
 echo "[+] Pushing git commit"
 # --set-upstream: sets de branch when pushing to a branch that does not exist
-git push "$GIT_CMD_REPOSITORY" --set-upstream "$TARGET_BRANCH"
+git push "$GIT_CMD_REPOSITORY" --set-upstream "$TARGET_BRANCH" --force


### PR DESCRIPTION
This pull request introduces a new optional `force-push` input to the GitHub Action, allowing users to force push changes to the target repository branch if needed. Additionally, it standardizes the formatting of input fields in `action.yml` for consistency.

**New functionality:**

* Added a `force-push` boolean input to `action.yml` that, when set to `true`, will force push the commit to the target branch.
* Updated `entrypoint.sh` to accept the new `force-push` argument and conditionally perform a `git push --force` based on its value. [[1]](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R19) [[2]](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R176-R181)

**Formatting and consistency improvements:**

* Standardized the use of double quotes for input descriptions and default values in `action.yml` for improved readability and consistency. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L22-R34) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L48-R80)